### PR TITLE
Type fixes for dayjs 1.11.2+

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "coveralls": "npm run test && cat coverage/lcov.info | coveralls"
   },
   "dependencies": {
-    "dayjs": "^1.10.0"
+    "dayjs": "^1.11.2"
   },
   "eslintConfig": {
     "env": {

--- a/src/results.ts
+++ b/src/results.ts
@@ -3,7 +3,7 @@ import { Component, ParsedComponents, ParsedResult, ParsingReference } from "./i
 import quarterOfYear from "dayjs/plugin/quarterOfYear";
 import weekday from "dayjs/plugin/weekday";
 
-import dayjs, { OpUnitType, QUnitType } from "dayjs";
+import dayjs, { OpUnitType, QUnitType, ManipulateType } from "dayjs";
 import { assignSimilarDate, assignSimilarTime, implySimilarTime } from "./utils/dayjs";
 import { toTimezoneOffset } from "./timezone";
 dayjs.extend(quarterOfYear);
@@ -183,7 +183,7 @@ export class ParsingComponents implements ParsedComponents {
     ): ParsingComponents {
         let date = dayjs(reference.instant);
         for (const key in fragments) {
-            date = date.add(fragments[key as OpUnitType], key as OpUnitType);
+            date = date.add(fragments[key], key as ManipulateType);
         }
 
         const components = new ParsingComponents(reference);

--- a/src/utils/timeunits.ts
+++ b/src/utils/timeunits.ts
@@ -1,4 +1,4 @@
-import { OpUnitType, QUnitType } from "dayjs";
+import { OpUnitType, QUnitType, ManipulateType } from "dayjs";
 import { ParsingComponents } from "../results";
 
 export type TimeUnits = { [c in OpUnitType | QUnitType]?: number };
@@ -19,7 +19,7 @@ export function addImpliedTimeUnits(components: ParsingComponents, timeUnits: Ti
     let date = components.dayjs();
     for (const key in timeUnits) {
         // noinspection JSUnfilteredForInLoop
-        date = date.add(timeUnits[key], key as OpUnitType);
+        date = date.add(timeUnits[key], key as ManipulateType);
     }
 
     if ("day" in timeUnits || "d" in timeUnits || "week" in timeUnits || "month" in timeUnits || "year" in timeUnits) {


### PR DESCRIPTION
The dayjs version specifier ^1.10.0 currently pulls in 1.11.2, but this release contains non-backward compatible changes.

This pull request fixes building against it.